### PR TITLE
fix: polish docs layout and highlighting

### DIFF
--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { FC } from "react";
 import { getHighlighter, type Highlighter } from "shiki";
+import onigWasm from "shiki/onig.wasm?url";
 import voyGrammar from "../../assets/voyd.tmLanguage.json";
 
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -18,6 +19,7 @@ function loadHighlighter(): Promise<Highlighter> {
           grammar: voyGrammar,
         } as any,
       ],
+      wasm: onigWasm,
     });
   }
   return highlighterPromise!;
@@ -40,7 +42,7 @@ const CodeBlock: FC<Props> = ({ code, lang = "voyd" }) => {
       setHtml(
         highlighted.replace(
           '<pre class="shiki"',
-          '<pre class="shiki rounded-md p-4 overflow-x-auto shadow"'
+          '<pre class="shiki rounded-md p-6 overflow-x-auto shadow w-full"'
         )
       );
     });
@@ -51,7 +53,7 @@ const CodeBlock: FC<Props> = ({ code, lang = "voyd" }) => {
   }
 
   return (
-    <div className="relative">
+    <div className="relative w-full">
       <div dangerouslySetInnerHTML={{ __html: html }} />
       <button
         onClick={copy}

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -72,8 +72,8 @@ export default function Docs() {
   };
 
   return (
-    <main className="flex max-w-5xl mx-auto py-16 px-4 gap-8">
-      <aside className="hidden md:block w-64 sticky top-20 h-max">
+    <main className="flex w-full max-w-6xl mx-auto py-16 px-4 gap-8">
+      <aside className="hidden md:block w-64 flex-shrink-0 sticky top-20 h-max">
         <nav className="space-y-2 text-sm">
           {headings.map((h) => (
             <a
@@ -88,7 +88,7 @@ export default function Docs() {
           ))}
         </nav>
       </aside>
-      <div className="flex-1 space-y-8">
+      <div className="flex-1 min-w-0 max-w-3xl space-y-8">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeSlug]}


### PR DESCRIPTION
## Summary
- load Shiki's oniguruma wasm to restore Voyd syntax highlighting
- widen and pad code blocks while keeping them within page width
- constrain docs layout to a consistent max width to stop sidebar jumping

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd8d0fc84832aacee027b247c6d68