### PR TITLE
Use GitHub dark theme and simplify docs nav

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1,16 +1,14 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 @theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 html,
 body {
   background-color: #0d1117;
   color: #c9d1d9;
-}
-
-a {
-  color: #58a6ff;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -7,6 +7,10 @@
 
 html,
 body {
-  @apply bg-black text-gray-100;
-  background: radial-gradient(circle at center, #1f2937, #000000);
+  background-color: #0d1117;
+  color: #c9d1d9;
+}
+
+a {
+  color: #58a6ff;
 }

--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -58,7 +58,7 @@ const CodeBlock: FC<Props> = ({ code, lang = "voyd" }) => {
       <div dangerouslySetInnerHTML={{ __html: html }} />
       <button
         onClick={copy}
-        className="absolute top-2 right-2 text-xs px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 over"
+        className="absolute top-2 right-2 text-xs px-2 py-1 rounded bg-[#21262d] text-[#c9d1d9] hover:bg-[#30363d]"
       >
         Copy
       </button>

--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -5,7 +5,6 @@ import voydGrammar from "../../assets/voyd.tmLanguage.json";
 
 let highlighterPromise: Promise<Highlighter> | null = null;
 function loadHighlighter(): Promise<Highlighter> {
-  console.log(voydGrammar.scopeName);
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
       themes: ["github-dark"],
@@ -39,7 +38,7 @@ const CodeBlock: FC<Props> = ({ code, lang = "voyd" }) => {
             pre(node) {
               this.addClassToHast(
                 node,
-                "size-full rounded p-4 overflow-x-scroll"
+                "not-prose size-full rounded p-4 overflow-x-scroll"
               );
             },
           },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -34,17 +34,19 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        <header className="bg-black/80 text-gray-100 backdrop-blur-sm">
+        <header className="bg-[#161b22]/80 text-[#c9d1d9] backdrop-blur-sm">
           <div className="max-w-5xl mx-auto flex items-center justify-between p-4">
             <a href="/" className="flex items-center gap-2 font-bold text-xl">
               <img src={logo} alt="Voyd logo" className="h-8 w-8" />
               <span>Voyd</span>
             </a>
             <nav className="flex gap-4">
-              <a href="/docs" className="hover:underline">Docs</a>
+              <a href="/docs" className="hover:underline text-[#58a6ff]">
+                Docs
+              </a>
               <a
                 href="https://github.com/voyd-lang/voyd"
-                className="hover:underline"
+                className="hover:underline text-[#58a6ff]"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/docs";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import readme from "../../docs/README.md?raw";
@@ -12,7 +12,10 @@ export const prerender = true;
 export function meta({}: Route.MetaArgs) {
   return [
     { title: "Voyd Documentation" },
-    { name: "description", content: "Documentation for the Voyd programming language." },
+    {
+      name: "description",
+      content: "Documentation for the Voyd programming language.",
+    },
   ];
 }
 
@@ -60,23 +63,20 @@ export default function Docs() {
     return () => els.forEach((el) => observer.unobserve(el));
   }, []);
 
-  const components = {
-    code({ node, inline, className, children, ...props }: any) {
+  const components: Components = {
+    code({ className, children }) {
       const match = /language-(\w+)/.exec(className || "");
       const lang = match ? match[1] : "voyd";
-      if (inline) {
-        return (
-          <code className={className} {...props}>
-            {children}
-          </code>
-        );
-      }
+
       return (
         <CodeBlock
           code={String(children).replace(/\n$/, "")}
           lang={lang === "rust" ? "voyd" : lang}
         />
       );
+    },
+    pre({ node: _node, ...props }) {
+      return <pre className="not-prose" {...props} />;
     },
   };
 
@@ -95,11 +95,11 @@ export default function Docs() {
           ))}
         </nav>
       </aside>
-      <div className="flex-1 min-w-0 max-w-3xl space-y-8">
+      <div className="flex-1 min-w-0 max-w-3xl space-y-8 prose prose-invert">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeSlug]}
-          components={components as any}
+          components={components}
         >
           {readme}
         </ReactMarkdown>
@@ -107,7 +107,7 @@ export default function Docs() {
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeSlug]}
-          components={components as any}
+          components={components}
         >
           {basics}
         </ReactMarkdown>

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -3,9 +3,8 @@ import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import readme from "../../docs/README.md?raw";
-import basics from "../../docs/basics.md?raw";
 import CodeBlock from "../components/CodeBlock";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const prerender = true;
 
@@ -19,55 +18,68 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 
-export default function Docs() {
-  const headings = useMemo(() => {
-    const all = [readme, basics].join("\n");
-    const regex = /^(##+)\s+(.*)$/gm;
-    const out: { id: string; text: string; level: number }[] = [];
-    let m: RegExpExecArray | null;
-    while ((m = regex.exec(all))) {
-      const level = m[1].length;
-      const text = m[2].trim();
-      const id = text
-        .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, "")
-        .replace(/\s+/g, "-");
-      out.push({ id, text, level });
-    }
-    return out;
-  }, []);
+type Heading = { id: string; text: string; level: number };
 
+export default function Docs() {
+  const [headings, setHeadings] = useState<Heading[]>([]);
   const navRef = useRef<HTMLDivElement>(null);
+  const articleRef = useRef<HTMLDivElement>(null);
+
+  // Build headings (h2–h3) from the rendered DOM.
   useEffect(() => {
+    const root = articleRef.current;
+    if (!root) return;
+
+    const nodes = Array.from(
+      root.querySelectorAll("h2, h3")
+    ) as HTMLHeadingElement[];
+
+    const list: Heading[] = nodes
+      .map((h) => {
+        const level = Number(h.tagName.slice(1)); // 2, or 3
+        const text = (h.textContent || "").trim();
+        const id = h.id || "";
+        return id && text ? { id, text, level } : null;
+      })
+      .filter(Boolean) as Heading[];
+
+    setHeadings(list);
+  }, [readme]);
+
+  // Scroll spy: highlight active heading in the nav.
+  useEffect(() => {
+    const root = articleRef.current;
+    if (!root || headings.length === 0) return;
+
+    const targets = Array.from(root.querySelectorAll("h2, h3"));
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const id = entry.target.id;
-            const nav = navRef.current;
-            if (!nav) return;
-            nav.querySelectorAll("a").forEach((a) => {
-              if (a.getAttribute("href") === `#${id}`) {
-                a.classList.add("text-[#58a6ff]", "font-medium");
-              } else {
-                a.classList.remove("text-[#58a6ff]", "font-medium");
-              }
-            });
-          }
-        });
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const id = (entry.target as HTMLElement).id;
+          const nav = navRef.current;
+          if (!nav || !id) continue;
+
+          nav.querySelectorAll("a").forEach((a) => {
+            if (a.getAttribute("href") === `#${id}`) {
+              a.classList.add("text-[#58a6ff]", "font-medium");
+            } else {
+              a.classList.remove("text-[#58a6ff]", "font-medium");
+            }
+          });
+        }
       },
       { rootMargin: "0px 0px -80% 0px" }
     );
-    const els = Array.from(document.querySelectorAll("h2, h3"));
-    els.forEach((el) => observer.observe(el));
-    return () => els.forEach((el) => observer.unobserve(el));
-  }, []);
+
+    targets.forEach((el) => observer.observe(el));
+    return () => targets.forEach((el) => observer.unobserve(el));
+  }, [headings]);
 
   const components: Components = {
     code({ className, children }) {
       const match = /language-(\w+)/.exec(className || "");
       const lang = match ? match[1] : "voyd";
-
       return (
         <CodeBlock
           code={String(children).replace(/\n$/, "")}
@@ -81,21 +93,28 @@ export default function Docs() {
   };
 
   return (
-    <main className="flex w-full max-w-6xl mx-auto py-16 px-4 gap-8">
+    <main className="flex w-full max-w-5xl mx-auto py-16 px-4 gap-8">
       <aside className="hidden md:block w-64 flex-shrink-0 sticky top-20 h-max">
         <nav ref={navRef} className="space-y-2 text-sm">
           {headings.map((h) => (
             <a
               key={h.id}
               href={`#${h.id}`}
-              className={`block hover:underline ${h.level === 3 ? "ml-4" : ""} text-[#8b949e]`}
+              className={[
+                "block hover:underline text-[#8b949e]",
+                h.level === 3 ? "ml-4" : "",
+              ].join(" ")}
             >
               {h.text}
             </a>
           ))}
         </nav>
       </aside>
-      <div className="flex-1 min-w-0 max-w-3xl space-y-8 prose prose-invert">
+
+      <article
+        ref={articleRef}
+        className="flex-1 min-w-0 max-w-3xl space-y-8 prose prose-invert"
+      >
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeSlug]}
@@ -103,15 +122,7 @@ export default function Docs() {
         >
           {readme}
         </ReactMarkdown>
-        <hr className="my-8" />
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeSlug]}
-          components={components}
-        >
-          {basics}
-        </ReactMarkdown>
-      </div>
+      </article>
     </main>
   );
 }

--- a/app/routes/docs.tsx
+++ b/app/routes/docs.tsx
@@ -5,7 +5,7 @@ import rehypeSlug from "rehype-slug";
 import readme from "../../docs/README.md?raw";
 import basics from "../../docs/basics.md?raw";
 import CodeBlock from "../components/CodeBlock";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 export const prerender = true;
 
@@ -34,13 +34,22 @@ export default function Docs() {
     return out;
   }, []);
 
-  const [active, setActive] = useState<string>("");
+  const navRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            setActive(entry.target.id);
+            const id = entry.target.id;
+            const nav = navRef.current;
+            if (!nav) return;
+            nav.querySelectorAll("a").forEach((a) => {
+              if (a.getAttribute("href") === `#${id}`) {
+                a.classList.add("text-[#58a6ff]", "font-medium");
+              } else {
+                a.classList.remove("text-[#58a6ff]", "font-medium");
+              }
+            });
           }
         });
       },
@@ -74,14 +83,12 @@ export default function Docs() {
   return (
     <main className="flex w-full max-w-6xl mx-auto py-16 px-4 gap-8">
       <aside className="hidden md:block w-64 flex-shrink-0 sticky top-20 h-max">
-        <nav className="space-y-2 text-sm">
+        <nav ref={navRef} className="space-y-2 text-sm">
           {headings.map((h) => (
             <a
               key={h.id}
               href={`#${h.id}`}
-              className={`block hover:underline ${h.level === 3 ? "ml-4" : ""} ${
-                active === h.id ? "text-indigo-600 font-medium" : "text-gray-400"
-              }`}
+              className={`block hover:underline ${h.level === 3 ? "ml-4" : ""} text-[#8b949e]`}
             >
               {h.text}
             </a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ pub fn main()
 
 Voyd is in it's very early stages of development. Voyd is not ready for production use. Some syntax and semantics are still subject to change. Expect frequent breaking changes.
 
-All features documented in README Overview are fully implemented unless otherwise stated. Features documented in the [reference](./reference/) are not yet marked with status and may not be implemented.
+Not all features are implemented. See tests in the github repo for the most
+up to date information on what features have been implemented.
 
 **Features**:
 
@@ -36,7 +37,7 @@ All features documented in README Overview are fully implemented unless otherwis
 - Balance a great developer experience with performance
 - Play nice with others
 
-# Getting Started
+## Getting Started
 
 **Install**
 
@@ -128,8 +129,6 @@ Voyd also supports uniform function call syntax (UFCS), allowing functions to be
 ```
 
 ### Labeled arguments
-
-> Status: Not yet implemented
 
 Labeled arguments can be defined by wrapping parameters you wish to be labeled
 on call in curly braces.
@@ -377,8 +376,6 @@ fn do_work(o: Object)
 
 ## Closures
 
-> Status: Not yet implemented
-
 ```rust
 let double = n => n * 2
 
@@ -386,6 +383,8 @@ array.map n => n * 2
 ```
 
 Voyd also supports a concise syntax for passing closures to labeled arguments:
+
+> status: not yet implemented
 
 ```rust
 try do():
@@ -409,7 +408,7 @@ squared(x)
 
 ## Generics
 
-> Status: Basic implementation complete for objects, functions, impls, and type aliases. Inference is not yet supported.
+> Status: Mostly complete. Constraints not yet implemented.
 
 ```rust
 fn add<T>(a: T, b: T) -> T

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@react-router/dev": "^7.7.1",
+        "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.4",
         "@types/node": "^20",
         "@types/react": "^19.1.2",
@@ -1875,6 +1876,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.11.tgz",
@@ -2572,6 +2589,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -3813,6 +3843,27 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5170,6 +5221,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
@@ -6283,6 +6348,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-router": "^7.7.1",
-    "remark-gfm": "^4.0.1",
     "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "shiki": "^1.27.2"
   },
   "devDependencies": {
     "@react-router/dev": "^7.7.1",
+    "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",
     "@types/react": "^19.1.2",


### PR DESCRIPTION
## Summary
- Replace gradient background with GitHub dark colors and apply matching link and header styles
- Simplify docs navigation highlighting to avoid scroll flicker
- Align CodeBlock copy button styling with GitHub dark theme

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689be4d61b28832aaafb5402cb137257